### PR TITLE
Nova brand colors support

### DIFF
--- a/resources/views/layout/default.blade.php
+++ b/resources/views/layout/default.blade.php
@@ -9,7 +9,11 @@
 
     <!-- Styles -->
     <link rel="stylesheet" href="{{ mix('app.css', 'vendor/nova') }}">
-    
+
+    <style>
+        {{ Nova::brandColorsCSS() }}
+    </style>
+
     <script>
         if (localStorage.novaTheme === 'dark' || (!('novaTheme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
             document.documentElement.classList.add('dark')


### PR DESCRIPTION
Button on the prompt page was still in the default color despite we have set custom colors in Nova settings. This Pull request adds support for custom colors. 