### PR TITLE
Add migration to cascade on user deletion action

### DIFF
--- a/database/migrations/2023_03_01_093631_update_constraints_cascade_on_delete_on_two_fa.php
+++ b/database/migrations/2023_03_01_093631_update_constraints_cascade_on_delete_on_two_fa.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class UpdateConstraintsCascadeOnDeleteOnTwoFa extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('nova_twofa', function (Blueprint $table) {
+            $table->dropForeign('nova_twofa_user_id_foreign');
+            $table->foreign('user_id')
+                ->references(config('nova-two-factor.user_id_column'))
+                ->on(config('nova-two-factor.user_table'))
+                ->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('nova_twofa', function (Blueprint $table) {
+            $table->dropForeign('nova_twofa_user_id_foreign');
+            $table->foreign('user_id')
+                ->references(config('nova-two-factor.user_id_column'))
+                ->on(config('nova-two-factor.user_table'));
+        });
+    }
+}


### PR DESCRIPTION
Hi,

I noticed that it wasn't possible to delete a user that had the 2FA setup.
This PR adds a new migration to enable OnDelete Cascade in case a user is deleted, that way the 2FA row is deleted as well.