### PR TITLE
Removed hard-coded dependencies

### DIFF
--- a/src/Http/Controller/TwoFactorController.php
+++ b/src/Http/Controller/TwoFactorController.php
@@ -2,7 +2,6 @@
 
 namespace Visanduma\NovaTwoFactor\Http\Controller;
 
-use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
@@ -11,7 +10,7 @@ use PragmaRX\Google2FA\Google2FA as G2fa;
 use Visanduma\NovaTwoFactor\Models\TwoFa;
 use Visanduma\NovaTwoFactor\TwoFaAuthenticator;
 
-class TwoFactorController extends Controller
+class TwoFactorController
 {
     private $novaGuard;
 
@@ -46,9 +45,9 @@ class TwoFactorController extends Controller
 
 
         $userTwoFa = new TwoFa();
-        $userTwoFa::where('user_id', auth($this->novaGuard)->user()->id)->delete();
+        $userTwoFa::where('user_id', auth($this->novaGuard)->id())->delete();
         $user2fa = new $userTwoFa();
-        $user2fa->user_id = auth($this->novaGuard)->user()->id;
+        $user2fa->user_id = auth($this->novaGuard)->id();
         $user2fa->google2fa_secret = $secretKey;
         $user2fa->recovery = $recoveryKeyHashed;
         $user2fa->save();


### PR DESCRIPTION
Removed dependency of `\App\Http\Controllers\Controller`

If an app wasn't using `App` as its root namespace, this library was broken. There was also no point of extending `Controller` as its functionality wasn't used in `TwoFactorController`.

Replaced `auth()->user()->id` for `auth()->id()`

Makes accessing the ID of the user more generic. Doesn't depend on how the column was named in the database.