### PR TITLE
Setting the guard when validating current password

### DIFF
--- a/src/Http/Controller/TwoFactorController.php
+++ b/src/Http/Controller/TwoFactorController.php
@@ -186,7 +186,7 @@ class TwoFactorController extends Controller
         }
 
         $request->validate([
-            'password' => 'required|current_password'
+            'password' => 'required|current_password:' . config('nova.guard')
         ]);
 
         $this->novaUser()->twoFa()->delete();


### PR DESCRIPTION
When the default guard is not the same as the nova guard, this validation would fail. This PR addresses that.

Issue reported here https://github.com/Visanduma/nova-two-factor/issues/33#issuecomment-1564705646
