### PR TITLE
Add connection name for model Two2FA and fixes some translations keys

### DIFF
--- a/config/nova-two-factor.php
+++ b/config/nova-two-factor.php
@@ -13,9 +13,11 @@ return [
 
     'user_id_column' => 'id',
 
+    'connection_name' => env('DB_CONNECTION'),
+
     /* Encrypt the google secret values saved in database */
     'encrypt_google2fa_secrets' => false,
-    
+
     /* QR code can be generate using  Google API or inbuilt 'BaconQrCode' package*/
     'use_google_qr_code_api' => true,
 

--- a/resources/js/components/Tool.vue
+++ b/resources/js/components/Tool.vue
@@ -38,7 +38,7 @@
 
                     <div v-else class="">
                         <p>
-                            {{ __(`Two factor authentication (2FA) strengthens access security by requiring two methods (also referred to as factors) to verify your identity.Two factor authentication protects against phishing, social engineering and password brute force attacks and secures your logins from attackers exploiting weak or stolen credentials.`) }}
+                            {{ __(`Two factor authentication (2FA) strengthens access security by requiring two methods (also referred to as factors) to verify your identity. Two factor authentication protects against phishing, social engineering and password brute force attacks and secures your logins from attackers exploiting weak or stolen credentials.`) }}
                         </p>
 
                         <h3 class="tw-my-2 tw-text-xl">{{ __('Recovery codes') }}</h3>

--- a/resources/views/sign-in.blade.php
+++ b/resources/views/sign-in.blade.php
@@ -37,7 +37,7 @@
             <div class="flex mt-3 mb-6">
 
                 <div class="ml-auto">
-                    {{ __('Not working?') }} <a href="{{ route('nova-two-factor.recover') }}">{{ __('Use recovery code') }}</a>
+                    {{ __('Not working ?') }} <a href="{{ route('nova-two-factor.recover') }}">{{ __('Use recovery code') }}</a>
                     <br>
                 </div>
             </div>

--- a/src/Http/Controller/TwoFactorController.php
+++ b/src/Http/Controller/TwoFactorController.php
@@ -2,7 +2,6 @@
 
 namespace Visanduma\NovaTwoFactor\Http\Controller;
 
-use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
@@ -12,7 +11,7 @@ use Visanduma\NovaTwoFactor\Helpers\NovaUser;
 use Visanduma\NovaTwoFactor\Models\TwoFa;
 use Visanduma\NovaTwoFactor\TwoFaAuthenticator;
 
-class TwoFactorController extends Controller
+class TwoFactorController
 {
     use  NovaUser;
 

--- a/src/Models/TwoFa.php
+++ b/src/Models/TwoFa.php
@@ -16,6 +16,11 @@ class TwoFa extends Model
         'google2fa_enable' => 'boolean'
     ];
 
+    public function getConnectionName()
+    {
+        return config('nova-two-factor.connection_name') ?? config('database.default');
+    }
+
     public function user(): BelongsTo
     {
         return $this->belongsTo(config('nova-two-factor.user_model'));


### PR DESCRIPTION
Hi,

This PR allows to customize connection name of TwoAFA model.
Indeed, I work on a multi tenant website and some migrations are on a different connection

@lahirulhr 