### PR TITLE
Add rate limiter to authenticate endpoint

### DIFF
--- a/config/nova-two-factor.php
+++ b/config/nova-two-factor.php
@@ -47,4 +47,8 @@ return [
     /* timeout in minutes */
     'reauthorize_timeout' => 5,
 
+    'enable_max_attempts' => false,
+
+    'max_attempts_per_minute' => 3,
+
 ];


### PR DESCRIPTION
Adds a rate limit config option to prevent brute force attacks. Could be a good idea to enable it by default in the config file, but I left it disabled for now.  Thanks!