### PR TITLE
[hot-fix] Fix api route middleware

### DIFF
--- a/src/ToolServiceProvider.php
+++ b/src/ToolServiceProvider.php
@@ -63,7 +63,7 @@ class ToolServiceProvider extends ServiceProvider
         Nova::router(['nova', Authenticate::class, Authorize::class], 'nova-two-factor')
             ->group(__DIR__ . '/../routes/inertia.php');
 
-        Route::middleware(['nova', Authorize::class])
+        Route::middleware(['nova', Authenticate::class, Authorize::class])
             ->prefix('nova-vendor/nova-two-factor')
             ->group(__DIR__ . '/../routes/api.php');
     }


### PR DESCRIPTION
This PR ensures that api routes will use the `Laravel\Nova\Http\Middleware\Authenticate` middleware