### PR TITLE
Allow custom name in authenticator

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Change configs as your needs
 ``` 
 
 return [
+    // defaults to app.name when null
+    'display_name' => null,
     
      // enable or disable 2FA feature. default is enabled
     'enabled' => env('NOVA_TWO_FA_ENABLE',true),

--- a/config/nova-two-factor.php
+++ b/config/nova-two-factor.php
@@ -6,6 +6,8 @@
  * */
 
 return [
+    /* Will be used by authenticators, defaults to app.name if null */
+    'display_name' => null,
 
     'enabled' => env('NOVA_TWO_FA_ENABLE', true),
 

--- a/src/Http/Controller/TwoFactorController.php
+++ b/src/Http/Controller/TwoFactorController.php
@@ -69,7 +69,7 @@ class TwoFactorController
         $this->novaUser()->refresh();
 
         $url = null;
-        $company = config('app.name');
+        $company = config('nova-two-factor.display_name', config('app.name'));
         $email = $this->novaUser()->email;
         $secretKey = $this->novaUser()->twofa->google2fa_secret;
         $isSvg = false;


### PR DESCRIPTION
Hi,

This simple PR is to allow to use a custom name instead of defaulting to `app.name`

The changes made are not breaking changes, if `nova-two-factor.display_name` is `null`, it will default to `app.name`