### PR TITLE
Add 60 second timer to rate limit hits

### DIFF
--- a/src/Http/Controller/TwoFactorController.php
+++ b/src/Http/Controller/TwoFactorController.php
@@ -156,7 +156,7 @@ class TwoFactorController
                 return back()->withErrors([__('Too many attempts!')]);
             }
 
-            RateLimiter::hit($throttleKey);
+            RateLimiter::hit($throttleKey, 60);
         }
 
         $authenticator = app(TwoFaAuthenticator::class)->boot(request());


### PR DESCRIPTION
Fixes 2FA code rate limit hits persisting indefinitely