### PR TITLE
Update google2fa-laravel to v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "require": {
         "php": "^8.1",
         "bacon/bacon-qr-code": "^3.0",
-        "pragmarx/google2fa-laravel": "^2.0",
+        "pragmarx/google2fa-laravel": "^3.0",
         "laravel/nova": "^5.0"
     },
     "autoload": {


### PR DESCRIPTION
## Summary
- Upgrade `pragmarx/google2fa-laravel` from `^2.0` to `^3.0`.
- Supports Laravel 13 compatibility aligned with the upstream v3 package constraints.
- No PHP changes were needed; current `Support\Authenticator` usage, service provider auto-discovery, facade alias, and config structure remain compatible.

## Validation
- Scanned the codebase for `PragmaRX\Google2FALaravel`, `Google2FA`, facade/binding usage, and `google2fa` config keys.
- Checked v2 to v3 compatibility for service provider registration, facade usage, method signatures, and config structure.
- Tested successfully with my local Nova instance.
- Ran `composer validate`. `composer.json` is valid